### PR TITLE
Soften box-shadow effects across screens

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,7 +26,7 @@
             border: 3px solid #00ffff;
             border-radius: 15px;
             padding: 30px;
-            box-shadow: 0 0 30px #00ffff;
+            box-shadow: 0 0 10px rgba(0, 255, 255, 0.5);
             max-width: 900px;
         }
         
@@ -107,7 +107,7 @@
         .start-mission:hover:not(:disabled) {
             background: linear-gradient(45deg, #00cc00, #00ff00);
             transform: scale(1.05);
-            box-shadow: 0 0 20px #00ff00;
+            box-shadow: 0 0 10px rgba(0, 255, 0, 0.6);
         }
         
         .start-mission:disabled {
@@ -120,7 +120,7 @@
         #gameCanvas {
             border: 2px solid #00ffff;
             background: radial-gradient(ellipse at center, #001122 0%, #000000 100%);
-            box-shadow: 0 0 20px #00ffff;
+            box-shadow: 0 0 8px rgba(0, 255, 255, 0.4);
         }
         
         #gameInfo {
@@ -253,7 +253,7 @@
             text-align: center;
             display: none;
             border: 3px solid #00ff00;
-            box-shadow: 0 0 30px #00ff00;
+            box-shadow: 0 0 12px rgba(0, 255, 0, 0.5);
         }
         
         button {


### PR DESCRIPTION
## Summary
- Tone down prep screen glow
- Decrease start button hover halo
- Subtly shade game canvas and modal

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6892288ce4c4832e822bcf14b3114a25